### PR TITLE
Minor GTK3 buttons fix

### DIFF
--- a/themes/Bluecurve/gtk-3.0/gtk-style.css
+++ b/themes/Bluecurve/gtk-3.0/gtk-style.css
@@ -521,6 +521,7 @@ decoration:backdrop,
 .background.solid-csd headerbar:backdrop button.minimize,
 .background.solid-csd headerbar:backdrop button.maximize,
 .background.solid-csd headerbar:backdrop button.close {
+	margin-bottom: 1px;
 	border: 1px solid @headerbar_backdrop_button_border;
 	box-shadow: none;
 	background: linear-gradient(to bottom,


### PR DESCRIPTION
Same problem https://github.com/neeeeow/Bluecurve/issues/18. It only affects gtk3-widgets-factory for me since I don't have any other GTK3 application that use that type of CSD titlebar but i'm sure there's some out there. 

before: 
![before](https://github.com/user-attachments/assets/2bf806a1-48be-47e6-8c0d-c9f04377112b)

after:
![after](https://github.com/user-attachments/assets/c486f33d-2d07-4c03-bedc-da41b21aaaf0)
