### PR TITLE
GTK4 CSD shifting buttons fix

### DIFF
--- a/themes/Bluecurve/gtk-4.0/gtk-style.css
+++ b/themes/Bluecurve/gtk-4.0/gtk-style.css
@@ -484,6 +484,7 @@ tooltip.background.solid-csd,
 .background.solid-csd headerbar:backdrop button.minimize,
 .background.solid-csd headerbar:backdrop button.maximize,
 .background.solid-csd headerbar:backdrop button.close {
+	margin-bottom: 1px;
 	border: 1px solid @headerbar_backdrop_button_border;
 	box-shadow: none;
 	background: linear-gradient(to bottom,


### PR DESCRIPTION
Same shifting issue as https://github.com/neeeeow/Bluecurve/issues/18 but for GTK4. (application is Nicotine+)

before: 
![BEFORE_](https://github.com/user-attachments/assets/0644cdbd-19f4-464a-90f1-0e129571e94d)

after:
![AFTER_](https://github.com/user-attachments/assets/ce6764a0-6ed3-4a9a-b0d5-0f93e9f449f7)
